### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/copilot-setup-steps.yaml
+++ b/.github/workflows/copilot-setup-steps.yaml
@@ -1,4 +1,6 @@
 name: "Copilot NixOS Flake CI"
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/hbohlen/nixos/security/code-scanning/2](https://github.com/hbohlen/nixos/security/code-scanning/2)

To fix the issue, add a `permissions` key to the workflow YAML file to restrict GITHUB_TOKEN’s capabilities. The preferred approach is to add `permissions: contents: read` at the top-level of the workflow, immediately underneath the `name:` block and before `on:`, so that all jobs inherit the least privilege setting. This prevents jobs from requesting unnecessary write access to the repository. No additional imports or external libraries are needed for this change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
