### PR TITLE
Add GNOME secrets utilities to desktop module

### DIFF
--- a/modules/nixos/desktop.nix
+++ b/modules/nixos/desktop.nix
@@ -86,7 +86,7 @@
   environment.systemPackages = with pkgs; [
     # Browsers
     firefox
-    
+
     # Development IDEs and editors
     zed-editor
     vscode
@@ -114,6 +114,12 @@
     # Audio tools (essential for desktop)
     pavucontrol
     easyeffects
+
+    # Secrets management utilities
+    gnome-keyring
+    libsecret
+    seahorse
+    libgnome-keyring
   ];
 
   # Enable desktop services


### PR DESCRIPTION
## Summary
- add GNOME keyring and related utilities to the desktop package list so both secret-tool and Seahorse are available

## Testing
- not run (NixOS rebuild is not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d79dd624c4832b8bfed7b690a1b391