### PR TITLE
Add GNOME keyring packages to D-Bus configuration

### DIFF
--- a/modules/nixos/desktop.nix
+++ b/modules/nixos/desktop.nix
@@ -137,6 +137,11 @@
     };
   };
 
+  services.dbus.packages = [
+    pkgs.gnome-keyring
+    pkgs.gcr
+  ];
+
   # Enable desktop user services
   programs = {
     # DConf for GNOME settings


### PR DESCRIPTION
## Summary
- register gnome-keyring and gcr with the desktop module's D-Bus configuration so the secrets service can auto-activate

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d79e6083d0832bba3dddd21524bdbe