### PR TITLE
Add user systemd service for GNOME keyring

### DIFF
--- a/modules/nixos/desktop.nix
+++ b/modules/nixos/desktop.nix
@@ -142,6 +142,20 @@
     pkgs.gcr
   ];
 
+  systemd.user.services.gnome-keyring = {
+    Unit = {
+      Description = "GNOME Keyring Daemon";
+      Before = [ "graphical-session.target" ];
+    };
+    Service = {
+      ExecStart = "${pkgs.gnome-keyring}/bin/gnome-keyring-daemon --start --foreground --components=secrets,ssh,pkcs11";
+      Type = "forking";
+    };
+    Install = {
+      WantedBy = [ "default.target" ];
+    };
+  };
+
   # Enable desktop user services
   programs = {
     # DConf for GNOME settings


### PR DESCRIPTION
## Summary
- add a user-level systemd service for the GNOME keyring daemon in the desktop module to ensure it starts for non-GNOME sessions

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d79ed8e784832bbdc70c33b0287b45