### PR TITLE
Split NVIDIA configuration for desktop and laptop

### DIFF
--- a/hosts/AGENTS.md
+++ b/hosts/AGENTS.md
@@ -53,7 +53,7 @@ modules = [
   ../../modules/nixos/boot.nix          # Boot optimization
   ../../modules/nixos/desktop.nix       # Desktop environment
   ../../modules/nixos/development.nix   # Development tools
-  ../../modules/nixos/nvidia-rog.nix    # Graphics drivers
+  ../../profiles/graphics/nvidia-desktop.nix  # Desktop NVIDIA drivers
   ../../modules/nixos/impermanence.nix  # Ephemeral root
   ../../modules/nixos/users.nix         # User management
 ];
@@ -422,7 +422,8 @@ networking = {
     ../../modules/nixos/users.nix
     
     # Hardware-specific modules
-    ../../modules/nixos/nvidia-rog.nix # When applicable
+    ../../profiles/graphics/nvidia-desktop.nix  # Desktop NVIDIA (when applicable)
+    ../../profiles/graphics/nvidia-laptop.nix   # Laptop NVIDIA (when applicable)
     
     # External hardware profiles
     inputs.nixos-hardware.nixosModules.asus-zephyrus-gu603h  # When applicable

--- a/hosts/desktop/AGENTS.md
+++ b/hosts/desktop/AGENTS.md
@@ -11,7 +11,7 @@ This directory contains the desktop host configuration, optimized for a full des
 - Imports common system modules from `/modules/nixos/common.nix`
 - Imports ZFS and disk configuration from `./hardware/disko-zfs.nix` (host-specific)  
 - Imports impermanence configuration from `/modules/nixos/impermanence.nix`
-- Imports NVIDIA-specific configuration from `/modules/nixos/nvidia-rog.nix`
+- Imports NVIDIA-specific configuration from `/profiles/graphics/nvidia-desktop.nix`
 - References user configurations through Home Manager integration
 - Uses root-level flake.nix for system definition
 

--- a/hosts/desktop/default.nix
+++ b/hosts/desktop/default.nix
@@ -11,7 +11,7 @@
     ../../modules/nixos/desktop.nix
     ../../modules/nixos/development.nix  # Development tools for desktop
     ../../modules/nixos/impermanence.nix
-    ../../modules/nixos/nvidia-rog.nix
+    ../../profiles/graphics/nvidia-desktop.nix
     # Intel CPU and desktop PC hardware support
     inputs.nixos-hardware.nixosModules.common-cpu-intel
     inputs.nixos-hardware.nixosModules.common-pc

--- a/hosts/laptop/default.nix
+++ b/hosts/laptop/default.nix
@@ -12,7 +12,7 @@
     ../../modules/nixos/laptop.nix
     ../../modules/nixos/development.nix  # Development tools for laptop
     ../../modules/nixos/impermanence.nix
-    ../../modules/nixos/nvidia-rog.nix
+    ../../profiles/graphics/nvidia-laptop.nix
     ../../profiles/hardware/asus-rog-laptop.nix
   ];
 

--- a/hosts/laptop/simple.nix
+++ b/hosts/laptop/simple.nix
@@ -7,7 +7,7 @@
     ./hardware-configuration.nix
     ../../modules/nixos/common.nix
     ../../modules/nixos/users.nix
-    ../../modules/nixos/nvidia-rog.nix
+    ../../profiles/graphics/nvidia-laptop.nix
     inputs.nixos-hardware.nixosModules.asus-zephyrus-gu603h
   ];
 

--- a/modules/nixos/nvidia-rog.nix
+++ b/modules/nixos/nvidia-rog.nix
@@ -1,80 +1,34 @@
 # /modules/nixos/nvidia-rog.nix
-{ config, lib, pkgs, ... }:
+{ config, pkgs, lib, inputs, ... }:
 
 {
-  # NVIDIA driver configuration for ASUS ROG laptops
+  imports = [
+    ../../profiles/graphics/nvidia-laptop.nix
+  ];
+
+  warnings = [
+    "modules/nixos/nvidia-rog.nix is deprecated; migrate to profiles/graphics/nvidia-laptop.nix or profiles/graphics/nvidia-desktop.nix."
+  ];
+
   boot = {
-    # Blacklist nouveau to prevent conflicts with proprietary NVIDIA drivers
-    blacklistedKernelModules = [ "nouveau" ];
-    
-    # Load nvidia drivers early in the boot process
-    initrd.kernelModules = [ "nvidia" "nvidia_drm" "nvidia_modeset" ];
-    
-    # Additional kernel parameters for NVIDIA and system stability
-    kernelParams = [
-      "nvidia-drm.modeset=1"  # Enable DRM modesetting for NVIDIA
-      "nvidia-drm.fbdev=1"    # Enable framebuffer device
-      "nvidia.NVreg_PreserveVideoMemoryAllocations=1"  # Preserve video memory allocations
+    initrd.kernelModules = lib.mkDefault [ "nvidia" "nvidia_drm" "nvidia_modeset" ];
+    kernelParams = lib.mkDefault [
+      "nvidia-drm.modeset=1"
+      "nvidia-drm.fbdev=1"
+      "nvidia.NVreg_PreserveVideoMemoryAllocations=1"
     ];
   };
 
-  # NVIDIA configuration for ASUS ROG laptops
-  hardware = {
-         # Enable graphics with 32-bit support
-    graphics = {
-      enable = true;
-      enable32Bit = true;
-    };
-
-    # NVIDIA proprietary driver configuration
-    nvidia = {
-      # Modesetting is required for proper NVIDIA functionality
-      modesetting.enable = true;
-      
-      # Enable NVIDIA settings
-      nvidiaSettings = true;
-      
-      # Use open-source kernel modules for RTX/GTX 16xx and newer
-      # Set to false for older GPUs
-      open = false;
-      
-      # Power management for better battery life
-      powerManagement = {
-        enable = true;
-        finegrained = true;
-      };
-      
-      # Dynamic boost for better performance
-      dynamicBoost.enable = true;
-      
-      # Prime configuration for hybrid graphics
-      prime = {
-        offload = {
-          enable = true;
-          enableOffloadCmd = true;
-        };
-        # Configure bus IDs (you may need to adjust these based on your hardware)
-        # Run 'lspci | grep -i nvidia' and 'lspci | grep -i vga' to find your IDs
-        intelBusId = "PCI:0:2:0";
-        nvidiaBusId = "PCI:1:0:0";
-      };
-      
-      # Force the use of the proprietary driver
-      forceFullCompositionPipeline = true;
-    };
+  hardware.nvidia = {
+    dynamicBoost.enable = lib.mkDefault true;
+    forceFullCompositionPipeline = lib.mkDefault true;
   };
 
-  # Additional udev rules for NVIDIA and ASUS devices
   services.udev.extraRules = ''
     # NVIDIA GPU power management
     ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x030000", ATTR{power/control}="auto"
-    
+
     # Fix for ASUS keyboard backlight and other features
     ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="0b05", ATTR{idProduct}=="19b6", ATTR{power/autosuspend}="-1"
   '';
-
-  # Ensure X server uses NVIDIA drivers
-  services.xserver = {
-    videoDrivers = [ "nvidia" ];
-  };
 }

--- a/profiles/graphics/nvidia-desktop.nix
+++ b/profiles/graphics/nvidia-desktop.nix
@@ -1,0 +1,34 @@
+{ config, pkgs, lib, inputs, ... }:
+{
+  boot = {
+    blacklistedKernelModules = [ "nouveau" ];
+    initrd.kernelModules = [ "nvidia" "nvidia_drm" "nvidia_modeset" ];
+    kernelParams = [
+      "nvidia-drm.modeset=1"
+      "nvidia-drm.fbdev=1"
+      "nvidia.NVreg_PreserveVideoMemoryAllocations=1"
+    ];
+  };
+
+  hardware = {
+    graphics = {
+      enable = true;
+      enable32Bit = true;
+    };
+
+    nvidia = {
+      modesetting.enable = true;
+      nvidiaSettings = true;
+      open = false;
+
+      powerManagement = {
+        enable = true;
+        finegrained = false;
+      };
+
+      forceFullCompositionPipeline = false;
+    };
+  };
+
+  services.xserver.videoDrivers = [ "nvidia" ];
+}

--- a/profiles/graphics/nvidia-laptop.nix
+++ b/profiles/graphics/nvidia-laptop.nix
@@ -1,0 +1,33 @@
+{ config, pkgs, lib, inputs, ... }:
+{
+  boot.blacklistedKernelModules = [ "nouveau" ];
+
+  hardware = {
+    graphics = {
+      enable = true;
+      enable32Bit = true;
+    };
+
+    nvidia = {
+      modesetting.enable = true;
+      nvidiaSettings = true;
+      open = false;
+
+      powerManagement = {
+        enable = true;
+        finegrained = true;
+      };
+
+      prime = {
+        offload = {
+          enable = true;
+          enableOffloadCmd = true;
+        };
+        intelBusId = "PCI:0:2:0";
+        nvidiaBusId = "PCI:1:0:0";
+      };
+    };
+  };
+
+  services.xserver.videoDrivers = [ "nvidia" ];
+}


### PR DESCRIPTION
## Summary
- add dedicated NVIDIA graphics profiles for desktop and laptop targets
- update desktop and laptop host imports to consume the new profiles and refresh related documentation
- wrap the legacy nvidia-rog module around the laptop profile with a deprecation warning for future migration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7a16af0bc832b85852e0f2f68a690